### PR TITLE
exception handling fix

### DIFF
--- a/examples/basics.py
+++ b/examples/basics.py
@@ -36,7 +36,7 @@ def main():
         yield fail()
     except Exception as e:
         print("Caught exception:", type(e), str(e))
-
+        assert str(e) == "oroutine boo"
     try:
         yield invalid_yield()
     except InvalidYieldException as e:

--- a/monocle/core.py
+++ b/monocle/core.py
@@ -36,7 +36,12 @@ class InvalidYieldException(TypeError):
 def _o(f):
     @functools.wraps(f)
     def coroutine_wrapper(*a, **k):
-        gen_f = f(*a, **k)
+        gen_f = None
+        try:
+            gen_f = f(*a, **k)
+        except Exception as e:
+            # prevents exception from escaping the wrapper
+            return defer(e)
         if not isinstance(gen_f, types.GeneratorType):
             if isinstance(gen_f, Callback):
                 return gen_f

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py36
+    py37
 skipsdist = True
 
 [pytest]
@@ -10,7 +10,7 @@ python_files=test_*.py
 deps =
     pycodestyle
     pyOpenSSL
-    pytest==3.6
+    pytest
     pytest-xdist
     mock==2
 


### PR DESCRIPTION
This was breaking pytest fixture, because exception was escaping the coroutine.

We should return Callback(e) instead of e.