### PR TITLE
Handle invalid states, cancellations and timeouts better

### DIFF
--- a/monocle/core.py
+++ b/monocle/core.py
@@ -81,17 +81,14 @@ def _o(f):
         fut = asyncio.ensure_future(gen_wrapper())
         cb = Callback()
 
-        def _trigger_callback_with_future(fut):
+        def _trigger_callback_with_future(futura):
             try:
-                e = fut.exception()
-            except Exception as fe:
+                res = futura.result()
+            except Exception as ee:
                 # either future wasn't done yet or it got cancelled (e.g. timeout)
-                e = fe
+                res = ee
 
-            if e:
-                cb(e)
-            else:
-                cb(fut.result())
+            cb(res)
 
         fut.add_done_callback(_trigger_callback_with_future)
         return cb

--- a/monocle/core.py
+++ b/monocle/core.py
@@ -82,7 +82,12 @@ def _o(f):
         cb = Callback()
 
         def _trigger_callback_with_future(fut):
-            e = fut.exception()
+            try:
+                e = fut.exception()
+            except Exception as fe:
+                # either future wasn't done yet or it got cancelled (e.g. timeout)
+                e = fe
+
             if e:
                 cb(e)
             else:


### PR DESCRIPTION
Errors like these had escaped in the past:
```
2019-06-21 14:55:47,982 - asyncio[default_exception_handler:1266] - ERROR - Exception in callback _o.<locals>.coroutine_wrapper.<locals>._trigger_callback_with_future(<Task cancell...e/core.py:48>>) at /usr/lib/python3.6/site-packages/monocle/core.py:79
handle: <Handle _o.<locals>.coroutine_wrapper.<locals>._trigger_callback_with_future(<Task cancell...e/core.py:48>>) at /usr/lib/python3.6/site-packages/monocle/core.py:79>
Traceback (most recent call last):
  File "/usr/lib/python3.6/asyncio/events.py", line 145, in _run
    self._callback(*self._args)
  File "/usr/lib/python3.6/site-packages/monocle/core.py", line 80, in _trigger_callback_with_future
    e = fut.exception()
concurrent.futures._base.CancelledError
```

This can occur if future has been cancelled due to timeouts or other cancellations (e.g. the caller has disconnected or is not interested in the request anymore).